### PR TITLE
feat: supports cross OS file paths

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -2,15 +2,15 @@ const {homedir} = require('os');
 const sqlite = require('sqlite');
 const sqlite3 = require('sqlite3');
 const {fileExists} = require('./helpers');
+const path = require('path');
 
 /**
  * Opens the BurnDownStatus SQLite3 Database
- * @param file file name of the SQLite3 DB. If not provided, defaults to ${homedir}/BurnDownStatus.db
+ * @param file file name of the SQLite3 DB. If not provided, defaults to BurnDownStatus.db in the users home
  * @returns SQLite database connection
  */
 async function getDBConnection(file) {
-    const homeDir = homedir();
-    file = file ? file : `${homeDir}/BurnDownStatus.db`;
+    file = file ? file : path.join(homedir(),'BurnDownStatus.db');
     if (! await fileExists(file)){
         console.error(`${file} not found`);
         // ! Separation of concerns - this should probably not be doing the exiting, but it is.

--- a/src/database.test.js
+++ b/src/database.test.js
@@ -3,6 +3,7 @@ const sqlite = require('sqlite');
 const sqlite3 = require('sqlite3');
 const helpers = require('./helpers');
 const { getDBConnection } = require('./database');
+const path = require('path');
 
 jest.mock('sqlite');
 jest.mock('os');
@@ -32,7 +33,7 @@ describe('database module', () => {
         helpers.fileExists.mockReturnValue(true);
 
 
-        const expectedDefaultFile = `${os.homedir()}/BurnDownStatus.db`
+        const expectedDefaultFile = path.join(os.homedir(),'BurnDownStatus.db')
         
         const file = undefined;
         // call function with null file
@@ -56,7 +57,7 @@ describe('database module', () => {
         os.homedir.mockReturnValue(expectedHomeDir);
         helpers.fileExists.mockReturnValue(true);
 
-        const expectedDefaultFile = `${os.homedir()}/my_database.db`
+        const expectedDefaultFile = path.join(os.homedir(),'BurnDownStatus.db')
 
         const db = await getDBConnection(expectedDefaultFile)
 


### PR DESCRIPTION
Updates the database module to build the paths using `path.join()` rather than string concatenation.

Fixes #24
