### PR TITLE
tests(azure): Adds Azure storage unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beauraines/node-helpers",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "Collection of node helpers",
   "main": "index.js",
   "scripts": {

--- a/src/azure.js
+++ b/src/azure.js
@@ -149,6 +149,7 @@ getStorageQueueSignedURL(queueUrl,options) {
    * 
    * @param {string} containerName the container to which the file will be uploaded
    * @param {string} file The path the the local file to upload to the container
+   * @returns {boolean} Success or failure to upload
    */
   //TODO migrate to @azure/storage-blob
   uploadBlobFromFile(containerName,file) {
@@ -161,8 +162,11 @@ getStorageQueueSignedURL(queueUrl,options) {
     blobService.createBlockBlobFromLocalFile(containerName,blobName,file,options,function(error,response) {
       if( error) {
         console.error(error.message)
+        return false
       } else {
+        // TODO remove this from this function - separation of concerns, let the caller do the logging
         console.log(`${response.name} uploaded to ${response.container} container`)
+        return true
       }
     });
   }
@@ -183,8 +187,10 @@ getStorageQueueSignedURL(queueUrl,options) {
     const blobClient = containerClient.getBlobClient(blobName);
 
     const downloadBlockBlobResponse = await blobClient.download();
+    // TODO add a success and failure test
     let writer = fs.createWriteStream(file) 
     downloadBlockBlobResponse.readableStreamBody.pipe(writer)
+    // TODO remove this from this function - separation of concerns, let the caller do the logging
     console.log(`${blobName} downloaded to ${file}`)
 
   }

--- a/src/azure.js
+++ b/src/azure.js
@@ -1,5 +1,6 @@
 const azure = require('azure-storage');
 const dayjs = require('dayjs')
+const fs = require('fs');
 const { streamToBuffer } = require('./helpers.js')
 const { BlobServiceClient, StorageSharedKeyCredential } = require("@azure/storage-blob");
 const { QueueClient } = require("@azure/storage-queue");

--- a/src/azure.test.js
+++ b/src/azure.test.js
@@ -44,7 +44,7 @@ describe('Azure Storage module', () => {
 
     })
 
-    it('should generate a signed URL for a blob', () => {
+    it.skip('should generate a signed URL for a blob', () => {
         const account = "devstoreaccount1";
         const accountKey = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
         let containerName = 'node-helpers-testing'
@@ -65,7 +65,7 @@ describe('Azure Storage module', () => {
         expect(sasTokenParams.get('sp')).toBe('r') // Read only by default
     })
 
-    it('should upload a blob from a file',async () => {
+    it.skip('should upload a blob from a file',async () => {
         const account = "devstoreaccount1";
         const accountKey = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
         let containerName = 'node-helpers-testing'
@@ -77,7 +77,7 @@ describe('Azure Storage module', () => {
 
     it.todo('should send a message to the storage queue')
 
-    it('should get a blob from azure storage', async () =>{
+    it.skip('should get a blob from azure storage', async () =>{
         const account = "devstoreaccount1";
         const accountKey = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
         let containerName = 'node-helpers-testing'
@@ -89,7 +89,7 @@ describe('Azure Storage module', () => {
 
     })
 
-    it('should download a blob to a file', async () => {
+    it.skip('should download a blob to a file', async () => {
         const account = "devstoreaccount1";
         const accountKey = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
         let containerName = 'node-helpers-testing'
@@ -104,13 +104,16 @@ describe('Azure Storage module', () => {
 
 
 
-    it.todo('should list blobs from azure storage')
-    // const AzureStorage  = require('./azure.js')
-    // const account = "devstoreaccount1";
-    // const accountKey = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
-    // let containerName = 'blob1675448230584'
-    // let blobName = '00096798-51a1-42f3-bb70-333232323643.json'
-    // let azure = new AzureStorage(account,accountKey,{cloudName:'Azurite'})
-    // let blobs = await azure.listBlobs('test')
+    it.skip('should list blobs from azure storage', async () => {
+        const account = "devstoreaccount1";
+        const accountKey = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+        let containerName = 'node-helpers-testing'
+        let blobName = 'package.json'
+        let azure = new AzureStorage(account,accountKey,{cloudName:'Azurite'})
+        let blobs = await azure.listBlobs(containerName)
+        expect(Array.isArray(blobs));
+        expect(blobs.length).toBeGreaterThan(0)
+        expect(blobs.filter(b => b.name == blobName).length).toBe(1)
+    })
 
 })

--- a/src/azure.test.js
+++ b/src/azure.test.js
@@ -44,9 +44,28 @@ describe('Azure Storage module', () => {
 
     })
 
-    it.todo('should generate a signed URL for a blob')
+    it('should generate a signed URL for a blob', () => {
+        const account = "devstoreaccount1";
+        const accountKey = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+        let containerName = 'node-helpers-testing'
+        let blobName = 'package.json'
 
-    it.only('should upload a blob from a file',async () => {
+        let azure = new AzureStorage(account,accountKey,{cloudName:'Azurite'})
+        const options = {
+            tokenExpiry: 42
+        }
+        const signedUrl = azure.generateBlobSignedUrl(containerName,blobName,options)
+        let url = new URL(signedUrl)
+        const sasTokenParams = url.searchParams;
+
+        expect(signedUrl).toContain(azure.host('blob','Azurite'))
+        expect(dayjs(sasTokenParams.get('st')).isBefore(dayjs()))
+        expect(dayjs(sasTokenParams.get('se')).isAfter(dayjs()))
+        expect(dayjs(sasTokenParams.get('st')).add(azure.tokenExpiry).isSame(dayjs(sasTokenParams.get('se'))))
+        expect(sasTokenParams.get('sp')).toBe('r') // Read only by default
+    })
+
+    it('should upload a blob from a file',async () => {
         const account = "devstoreaccount1";
         const accountKey = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
         let containerName = 'node-helpers-testing'
@@ -55,10 +74,10 @@ describe('Azure Storage module', () => {
         let success = await azure.uploadBlobFromFile(containerName,file)
         expect(success)
     })
-    
+
     it.todo('should send a message to the storage queue')
 
-    it.only('should get a blob from azure storage', async () =>{
+    it('should get a blob from azure storage', async () =>{
         const account = "devstoreaccount1";
         const accountKey = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
         let containerName = 'node-helpers-testing'
@@ -79,7 +98,6 @@ describe('Azure Storage module', () => {
         let file = `/tmp/package.${dayjs().add()}.json`
         let azure = new AzureStorage(account,accountKey,{cloudName:'Azurite'})
         await azure.downloadBlobToFile(containerName,blobName,file)
-        // console.log(file)
         expect(fileExists(file))
     })
 

--- a/src/azure.test.js
+++ b/src/azure.test.js
@@ -1,7 +1,9 @@
 const dayjs = require('dayjs')
 const { fileExists } = require('./helpers.js')
 const AzureStorage  = require('./azure.js')
-
+const os = require('os');
+const path = require('path');
+  
 describe('Azure Storage module', () => {
 
     it('should be created with default values', () => {
@@ -94,8 +96,7 @@ describe('Azure Storage module', () => {
         const accountKey = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
         let containerName = 'node-helpers-testing'
         let blobName = 'package.json'
-        // TODO move this to the os temp dir
-        let file = `/tmp/package.${dayjs().add()}.json`
+        let file = path.join(os.tmpdir(),`package.${dayjs().unix()}.json`)
         let azure = new AzureStorage(account,accountKey,{cloudName:'Azurite'})
         await azure.downloadBlobToFile(containerName,blobName,file)
         expect(fileExists(file))

--- a/src/azure.test.js
+++ b/src/azure.test.js
@@ -1,3 +1,5 @@
+const dayjs = require('dayjs')
+const { fileExists } = require('./helpers.js')
 const AzureStorage  = require('./azure.js')
 
 describe('Azure Storage module', () => {
@@ -43,7 +45,54 @@ describe('Azure Storage module', () => {
     })
 
     it.todo('should generate a signed URL for a blob')
-    it.todo('should upload a blob from a file')
+
+    it.only('should upload a blob from a file',async () => {
+        const account = "devstoreaccount1";
+        const accountKey = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+        let containerName = 'node-helpers-testing'
+        let file = 'package.json'
+        let azure = new AzureStorage(account,accountKey,{cloudName:'Azurite'})
+        let success = await azure.uploadBlobFromFile(containerName,file)
+        expect(success)
+    })
+    
     it.todo('should send a message to the storage queue')
+
+    it.only('should get a blob from azure storage', async () =>{
+        const account = "devstoreaccount1";
+        const accountKey = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+        let containerName = 'node-helpers-testing'
+        let blobName = 'package.json'
+        let azure = new AzureStorage(account,accountKey,{cloudName:'Azurite'})
+        let file = await azure.getBlob(containerName,blobName)
+        file = JSON.parse(file)
+        expect(file.name).toBe("@beauraines/node-helpers")
+
+    })
+
+    it('should download a blob to a file', async () => {
+        const account = "devstoreaccount1";
+        const accountKey = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+        let containerName = 'node-helpers-testing'
+        let blobName = 'package.json'
+        // TODO move this to the os temp dir
+        let file = `/tmp/package.${dayjs().add()}.json`
+        let azure = new AzureStorage(account,accountKey,{cloudName:'Azurite'})
+        await azure.downloadBlobToFile(containerName,blobName,file)
+        // console.log(file)
+        expect(fileExists(file))
+    })
+
+
+
+
+    it.todo('should list blobs from azure storage')
+    // const AzureStorage  = require('./azure.js')
+    // const account = "devstoreaccount1";
+    // const accountKey = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+    // let containerName = 'blob1675448230584'
+    // let blobName = '00096798-51a1-42f3-bb70-333232323643.json'
+    // let azure = new AzureStorage(account,accountKey,{cloudName:'Azurite'})
+    // let blobs = await azure.listBlobs('test')
 
 })


### PR DESCRIPTION
Adds unit tests for azure storage functions, but all are skipped. These require a local running
instance of Azurite for testing with the package's `package.json` in a `node-helpers-testing` container.

This PR does not configure the Azurite containers for testing.

1. The container must be manually created.
2. Run the tests, one of which will create the file, but the suite will fail.
3. Run the tests again, which should succeed because the `package.json` will have been written to the blob by one of the earlier tests.
