### PR TITLE
chore: Update CI job to use current versions of node

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x,20.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x,20.x]
+        node-version: [16.x,18.x,20.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Node Helpers
 
-This is a set of helpers for node. They're written for quick reuse rather than robust functions or efficiency. For instance, the database functions will create a new database connection every time. This is not efficient, but it makes making the function call simple.
+This is a set of helpers for NodeJS. They're written for quick reuse rather than robust functions or efficiency. For instance, the database functions will create a new database connection every time. This is not efficient, but it makes making the function call simple.
 
-My use is primarily in quicker one off scripts that sometime morph into something long lasting...
+My use is primarily in quicker one-off scripts that sometimes morph into something long-lasting...
 
 
 ## Azure Storage
 
-Get blob from Azure example, downloads `bar.jpg` from `foo` container to `baz.jgp`
+Get blob from Azure example, downloads `bar.jpg` from `foo` container to `baz.jpg`
 
 ```javascript
 const AzureStorage  = require('./src/azure.js')


### PR DESCRIPTION
- Minor grammar updates to README
- updates test workflow to run on Node versions 18 and 20, dropping 16

Fixes #84
