### PR TITLE
ci: fixes publish to NPM

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -52,3 +52,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref }}
           tags: true
+          force: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@beauraines/node-helpers",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@beauraines/node-helpers",
-      "version": "4.0.5",
+      "version": "4.0.6",
       "license": "ISC",
       "dependencies": {
         "@azure/storage-blob": "^12.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beauraines/node-helpers",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "description": "Collection of node helpers",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
uses the `force` action to allow the changelog and version changes to be committed as part of the publish workflow
