### PR TITLE
feat(sparkline): formatting and option support

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -107,20 +107,24 @@ function getEpochMillis() {
 }
 
 
-// TODO Add unit test
-// Expected output last 30 days [1,5] ▁▂▄▆█ 5 from [1,2,3,4,5]
+
 /**
- * Generates a sparkline with labels
+ * Generates a sparkline optionally with labels
+ * 
+ * labelled sparkline includes a label, min, max and last value
+ *
+ * last 30 days [1,5] ▁▂▄▆█ 5
+ * 
+ * unlabled is just that ▁▂▄▆█
  * 
  * @param {array} data Array of values to plot in the sparkline
- * @param {string} label Text to display before sparkline
+ * @param {string} label Text to display before sparkline, if empty or null, will not display any labels
  * @param {object} options Optional options for display, e.g display min,max,last, range coercion
  * @returns 
  */
 // eslint-disable-next-line no-unused-vars
 function sparkline(data,label,options) {
   // TODO add handling if data is object
-  // let open = last30days.map( x=> x.open_count)
 
   // Assuming data is array
   const minValue = Math.min(...data)
@@ -131,8 +135,15 @@ function sparkline(data,label,options) {
   // not display https://github.com/sindresorhus/sparkly/blob/9e33eaff891c41e8fb8c8883f62e9821729a9882/index.js#L15
   // sparkly(open,{minimum:27,maximum:50})
 
-  // TODO add option to not display labels issue #148
-  return `${label} [${minValue},${maxValue}] ${sparkly(data.map( x=> x- minValue))} ${lastValue}`
+  data = data.map( x=> x- minValue)
+
+  let sparkline
+  if (label) {
+    sparkline = `${label} [${minValue},${maxValue}] ${sparkly(data)} ${lastValue}`
+  } else {
+    sparkline = sparkly(data)
+  }
+  return sparkline
 }
 
 /**

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -117,25 +117,40 @@ function getEpochMillis() {
  * 
  * unlabled is just that ▁▂▄▆█
  * 
+ * Options supported are
+ * 
+ * {
+ * coerceData: true, // coerces the minimum value to zero 
+ * }
+ * 
  * @param {array} data Array of values to plot in the sparkline
  * @param {string} label Text to display before sparkline, if empty or null, will not display any labels
  * @param {object} options Optional options for display, e.g display min,max,last, range coercion
+ * 
  * @returns 
  */
 // eslint-disable-next-line no-unused-vars
 function sparkline(data,label,options) {
-  // TODO add handling if data is object
 
+  options = {
+    coerceData: true,
+    ...options
+  }
+
+  // TODO add handling if data is object
   // Assuming data is array
   const minValue = Math.min(...data)
   const maxValue = Math.max(...data)
   const lastValue = data.slice(-1)[0]
 
-  // coerces the minimum value to zero because the mimimum option is only used for range validation, 
-  // not display https://github.com/sindresorhus/sparkly/blob/9e33eaff891c41e8fb8c8883f62e9821729a9882/index.js#L15
-  // sparkly(open,{minimum:27,maximum:50})
+  // This is the default behavior
+  if ( options.coerceData ) {
+    // coerces the minimum value to zero because the mimimum option is only used for range validation, 
+    // not display https://github.com/sindresorhus/sparkly/blob/9e33eaff891c41e8fb8c8883f62e9821729a9882/index.js#L15
+    // sparkly(open,{minimum:27,maximum:50})
+    data = data.map( x=> x- minValue)
+  }
 
-  data = data.map( x=> x- minValue)
 
   let sparkline
   if (label) {

--- a/src/helpers.test.js
+++ b/src/helpers.test.js
@@ -22,5 +22,13 @@ describe('helpers',()=> {
         expect(helper.sparkline(input,label)).toBe(expectedOutput)
     })
 
+    it('should return a sparkline with no range coercion',()=>{
+        const expectedOutput = '▂▄▅▇█'
+        const input = [1,2,3,4,5]
+        const label = ''
+        const options = { coerceData: false }
+        expect(helper.sparkline(input,label, options)).toBe(expectedOutput)
+    })
+
 })
 

--- a/src/helpers.test.js
+++ b/src/helpers.test.js
@@ -8,14 +8,19 @@ describe('helpers',()=> {
         expect(helper.toTitleCase(lowerString)).toBe(titleString);
     })
 
-    it('should return the correctly sparkline',()=>{
+    it('should return the correctly formatted sparkline',()=>{
         const expectedOutput = 'last 30 days [1,5] ▁▂▄▆█ 5'
         const input = [1,2,3,4,5]
         const label = 'last 30 days'
         expect(helper.sparkline(input,label)).toBe(expectedOutput)
-
     })
 
+    it('should return a sparkline with no additional labeling',()=>{
+        const expectedOutput = '▁▂▄▆█'
+        const input = [1,2,3,4,5]
+        const label = ''
+        expect(helper.sparkline(input,label)).toBe(expectedOutput)
+    })
 
 })
 


### PR DESCRIPTION
- **feat(sparkline): optionally make a sparkline wiht out the label and descriptive stats**
If no label is passed to teh sparkline(), it won't print the label, mix, max or latest value

- **feat(sparkline): option support for range coercion**
The default behavior is still to adjust thee range to be zero based. This allows for better relative display of the numbers.
If you need absolute numbers dislayed you can use the option `coerceData:false`
