### PR TITLE
feat(ado): new ADO auth function to use az login instead of PAT

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -461,6 +461,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.20.tgz",
       "integrity": "sha512-Y6jd1ahLubuYweD/zJH+vvOY141v4f9igNQAQ+MBgq9JlHS2iTsZKn1aMsb3vGccZsXI16VzTBw52Xx0DWmtnA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.13",
@@ -1926,6 +1927,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2327,6 +2329,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001517",
         "electron-to-chromium": "^1.4.477",
@@ -3447,15 +3450,6 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "devOptional": true
-    },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
@@ -4967,6 +4961,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",

--- a/tests/test-az-auth.js
+++ b/tests/test-az-auth.js
@@ -1,0 +1,13 @@
+const { getAdoApiWithAzCli } = require('../src/ado.js');
+
+async function run() {
+  try {
+    // pass path to your config file (same used by other scripts), or undefined if readConfig handles default
+    const ado = await getAdoApiWithAzCli('./adoUtilities.json');
+    console.log('workAPI, workItemAPI available:', !!ado.workAPI, !!ado.workItemAPI);
+  } catch (err) {
+    console.error('Auth failed:', err.message);
+  }
+}
+
+run();


### PR DESCRIPTION
Adds a new ADO auth funciton to get the token from `az account get-acces-token` rather than a PAT to streamline the process of getting a token. This is especially useful where PAT are short-lived or not available (or their use is looked down on).
